### PR TITLE
docs: bad command to test "at Specific Revision"

### DIFF
--- a/docs/test.md
+++ b/docs/test.md
@@ -126,14 +126,14 @@ To test changes end-to-end on client repository:
     /// tab | PIP
 
     ```shell
-    pip install git+https://github.com/TACC/mkdocs-tacc.git#work-in-progress
+    pip install "mkdocs-tacc[all] @ git+https://github.com/TACC/mkdocs-tacc.git#work-in-progress"
     ```
 
     ///
     /// tab | Poetry
 
     ```shell
-    poetry add git+https://github.com/TACC/mkdocs-tacc.git#work-in-progress
+    poetry add "mkdocs-tacc[all] @ git+https://github.com/TACC/mkdocs-tacc.git#work-in-progress"
     ```
 
     ///


### PR DESCRIPTION
## Overview

Fix command neglects to install all dependencies.

## Related

Clients locally testing a branch, e.g. https://github.com/TACC/TACC-Docs/pull/99 testing https://github.com/TACC/mkdocs-tacc/pull/24.

## Changes

- **fixed** command in a test doc

## Testing

1. https://github.com/TACC/TACC-Docs/pull/99

## UI

https://github.com/TACC/mkdocs-tacc/blob/docs/bad-test-specific-rev-command/docs/test.md#at-specific-revision