### PR TITLE
docs: fix "Real-Time" testing error when running client

### DIFF
--- a/docs/test.md
+++ b/docs/test.md
@@ -177,7 +177,7 @@ To test changes real-time on client repository:
 
     ```shell
     poetry remove mkdocs-tacc
-    poetry add --editable ../mkdocs-tacc # ¹
+    poetry add --editable ../mkdocs-tacc
     ```
 
     ////

--- a/docs/test.md
+++ b/docs/test.md
@@ -150,7 +150,7 @@ To test changes real-time on client repository:
     /// tab | PIP
 
     ```shell
-    pip install -e ../mkdocs-tacc
+    pip install -e "../mkdocs-tacc[all]"
     ```
 
     <small>Where `../mkdocs-tacc` is the path to your clone of this repository.</small>
@@ -159,7 +159,7 @@ To test changes real-time on client repository:
 
     ```shell
     pip uninstall mkdocs-tacc
-    pip install -e ../mkdocs-tacc
+    pip install -e "../mkdocs-tacc[all]"
     ```
 
     ////
@@ -168,7 +168,7 @@ To test changes real-time on client repository:
     /// tab | Poetry
 
     ```shell
-    poetry add --editable ../mkdocs-tacc
+    poetry add --editable ../mkdocs-tacc --extras=all
     ```
 
     <small>Where `../mkdocs-tacc` is the path to your clone of this repository.</small>
@@ -177,7 +177,7 @@ To test changes real-time on client repository:
 
     ```shell
     poetry remove mkdocs-tacc
-    poetry add --editable ../mkdocs-tacc
+    poetry add --editable ../mkdocs-tacc --extras=all
     ```
 
     ////


### PR DESCRIPTION
## Overview

Fix "Real-Time" testing to install all dependencies, to avoid errors running client with editable install of `mkdocs-tacc`.

## Changes

- **changed** "Real-Time" testing to install all dependencies
- **removed** unused footnote ref in command

## Testing

1. Set up "Real-Time" testing of `mkdocs-tacc` on a client with PIP.
2. No errors.
3. Set up "Real-Time" testing of `mkdocs-tacc` on a client with PIP.
4. No errors.