### PR TITLE
refactor: logo-svg-injection

### DIFF
--- a/mkdocs_tacc/tacc_readthedocs/css/tacc-theme/readthedocs-reskin.css
+++ b/mkdocs_tacc/tacc_readthedocs/css/tacc-theme/readthedocs-reskin.css
@@ -17,20 +17,10 @@
 
 /* to set automatic size for an SVG logo */
 
-/* FAQ: The `img` in selectors is removed so `svg` is also supported */
-/* NOTE: Selectors from theme.css */
-.wy-side-nav-search .wy-dropdown > a /*img*/.logo,
-.wy-side-nav-search > a /*img*/.logo {
+.wy-side-nav-search .wy-dropdown > a.logo :is(img, svg),
+.wy-side-nav-search > a.logo :is(img, svg) {
   width: 100%;
   padding: unset;
-}
-
-
-/* to recolor SVG logo */
-
-/* CAVEAT: Assumes a monochrome design */
-svg.logo [fill]:not([fill="none"]) {
-  fill: var(--global-color-primary--xx-dark);
 }
 
 
@@ -211,10 +201,10 @@ svg.logo [fill]:not([fill="none"]) {
 
 /* to remove space (margin, padding, whitespace) around logo */
 .wy-side-nav-search a,
-.wy-side-nav-search svg.logo {
+.wy-side-nav-search a.logo > svg {
   display: block;
 }
-.wy-side-nav-search > a:has(.logo) {
+.wy-side-nav-search > a.logo {
   padding-block: unset; /* to undo theme.css */
 }
 

--- a/mkdocs_tacc/tacc_readthedocs/js/tacc-theme/swapImgSvgWithRawSvg.module.js
+++ b/mkdocs_tacc/tacc_readthedocs/js/tacc-theme/swapImgSvgWithRawSvg.module.js
@@ -1,6 +1,1 @@
-import 'https://cdn.jsdelivr.net/npm/@iconfu/svg-inject@1.2.3/dist/svg-inject.min.js';
-
-/* To change an <img> loading a .svg to be that .svg inline (allows styling) */
-SVGInject( document.querySelectorAll('.logo'), {
-  onAllFinish: () => console.info('Image SVGs replaced with inline SVGs.')
-});
+import 'https://load-file.github.io/element.js';

--- a/mkdocs_tacc/tacc_readthedocs/main.html
+++ b/mkdocs_tacc/tacc_readthedocs/main.html
@@ -55,17 +55,24 @@
   {%- endblock %}
 
   {%- block site_name %}
+    {# TACC: #}{# To know whether logo is an SVG #}
+    {% set logo_is_svg = '.svg' in config.theme.logo|lower %}
+    {# /TACC #}
     {%- if config.theme.logo %}
-      {# TACC: #}{# To provide accessible text (in case <img> becomes <svg>) #}
-      {# FAQ: swapImgSvgWithRawSvg.js does not preserve `title` attribute #}
-      <a href="{{ nav.homepage.url|url }}" title="{{ config.site_name }} ({% trans %}Logo{% endtrans %})">
+      {# TACC: #}{# To provide accessible text (if <img> becomes <svg>) #}
+      {# FAQ: swapImgSvgWithRawSvg.js does not preserve `alt` attribute #}
+      <a href="{{ nav.homepage.url|url }}" class="logo" title="{{ config.site_name }} ({% trans %}Logo{% endtrans %})">
       {# /TACC #}
     {%- else %}
       <a href="{{ nav.homepage.url|url }}" class="icon icon-home"> {{ config.site_name }}
     {%- endif %}
     {%- if config.theme.logo %}
       {# TACC: #}{# To add site name to accessible text #}
-      <img src="{{ config.theme.logo|url }}" class="logo" alt="{{ config.site_name }} ({% trans %}Logo{% endtrans %})"/>
+      {% if config.theme.logo_svg_inject and logo_is_svg %}
+      <load-file replaceWith src="{{ config.theme.logo|url }}"></load-file>
+      {% else %}
+      <img src="{{ config.theme.logo|url }}" alt="{{ config.site_name }} ({% trans %}Logo{% endtrans %})"/>
+      {% endif %}
       {# /TACC #}
     {%- endif %}
     </a>

--- a/mkdocs_tacc/tacc_readthedocs/mkdocs_theme.yml
+++ b/mkdocs_tacc/tacc_readthedocs/mkdocs_theme.yml
@@ -17,6 +17,7 @@ hljs_languages:
   - markdown
   - yaml
 # "TACC" Theme Features
+logo_svg_inject: true
 portal_url: https://your-site.org
 portal_name: your-site.org
 # nav_redirects:


### PR DESCRIPTION
## Overview

- Use new JavaScript to inject SVG for logo.
- Move `logo` class (conditionally) to `<a>` around logo.

## Related

- fixes black image background in logo at https://wesleyboar.github.io/Digital-Rocks-Docs/

## Changes

- **updated** `.logo` styles
- **removed** client-specific (and unnecessary[^1]) svg color override
- **changed** JavaScript for injecting SVG
- **changed** HTML for injecting SVG
- **moved** `logo` class to `<a>` if it has a logo
- **changed** svg inject to depend on new setting, `config.theme.logo_svg_inject`
- **added** setting `config.theme.logo_svg_inject`

[^1]: TACC-Docs' SVG's `fill` attributes are accurate values.

## Testing

1.

## UI

…