### PR TITLE
docs: create from template

### DIFF
--- a/DEPLOYING.md
+++ b/DEPLOYING.md
@@ -2,9 +2,10 @@
 
 Deploys rely on [GitHub Pages](https://pages.github.com/) and [MkDocs command `gh-deploy`](https://www.mkdocs.org/user-guide/deploying-your-docs/).
 
-1. Run
+0. [Install dependencies.](https://tacc.github.io/mkdocs-tacc/test/#test-locally)
+1. Run the command to build and trigger a deploy.
     ```shell
-    poetry run mkdocs gh-deploy --force --theme tacc_readthedocs
+    mkdocs gh-deploy
     ```
 2. Wait for [GitHub action](https://github.com/TACC/mkdocs-tacc/actions) to complete.
 3. Load https://tacc.github.io/mkdocs-tacc/.

--- a/README.md
+++ b/README.md
@@ -2,21 +2,40 @@
 
 A [TACC](https://www.tacc.utexas.edu/)-styled [MkDocs](https://www.mkdocs.org/) theme based on **MkDocs**' own [ReadTheDocs theme](https://www.mkdocs.org/user-guide/choosing-your-theme/#readthedocs).
 
-## How to Install
+- **Either** [Create a New MkDocs-TACC Project](#create-a-new-mkdocs-tacc-project)
+- **Or** [Install Theme Into Existing MkDocs Project](#install-theme-into-existing-mkdocs-project)
 
-1. Install the theme (and optional dependencies) e.g.
+## Create a New MkDocs-TACC Project
+
+1. Create a repository from our [`mkdocs-tacc-client`](https://github.com/TACC/mkdocs-tacc-client) template. [How?][create-from-template]
+2. In your new repository:
+    - Change [all instances of `mkdocs-tacc-client`](https://github.com/search?q=repo%3ATACC%2Fmkdocs-tacc-client+%22mkdocs-tacc-client%22&type=code) to `your-project-name`.
+    - Change [all instances of `MkDocs-TACC`](https://github.com/search?q=repo%3ATACC%2Fmkdocs-tacc-client%20%22MkDocs-TACC%22&type=code) to `Your Project Name`.
+    - Rename [`mkdocs_tacc_client` directory](https://github.com/TACC/mkdocs-tacc-client/tree/main/mkdocs_tacc_client) to `your_project_name`.
+
+## Install Theme Into Existing MkDocs Project
+
+1. Enter the directory of your MkDocs project e.g.
+
+    ```shell
+    cd path/to/your/mkdocs/project
+    ```
+
+2. Install the theme (and optional dependencies) e.g.
 
     ```shell
     pip install "mkdocs-tacc[all]"
     ```
 
-2. In your `mkdocs.yml`:
+> [!NOTE]
+> We also offer [detailed instructions](https://tacc.github.io/mkdocs-tacc/) instead.
+
+## How to Use
+
+3. In your `mkdocs.yml`:
 
     - Set theme name as `tacc_readthedocs`.
     - Set [typical extensions for this theme](./docs/extensions.md#typical).
-
-> [!NOTE]
-> We also offer [detailed instructions](https://tacc.github.io/mkdocs-tacc/) instead.
 
 ## Known Clients
 
@@ -29,3 +48,5 @@ A [TACC](https://www.tacc.utexas.edu/)-styled [MkDocs](https://www.mkdocs.org/) 
 ## Contributing
 
 We welcome contributions. Read ["How to Contribute"](./CONTRIBUTING.md).
+
+[create-from-template]: https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template#creating-a-repository-from-a-template

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,23 @@ dl strong {
 }
 </style>
 
-## How to Install
+## How to Create a New Project
+
+/// hint
+
+For those with no documentation project yet or who want to start fresh.
+
+///
+
+Follow the steps in [Create a New MkDocs-TACC Project](https://github.com/TACC/mkdocs-tacc/#create-a-new-mkdocs-tacc-project).
+
+## How to Install on Existing Project
+
+/// note
+
+These steps assume you have an existing [MkDocs](https://www.mkdocs.org/) project.
+
+///
 
 1. Install the theme (with all or zero extra functionality).
 


### PR DESCRIPTION
## Overview

Update docs to instruct clients how to create a new project from a template:

- https://tacc.github.io/mkdocs-tacc/#how-to-create-a-new-project
- https://github.com/TACC/mkdocs-tacc/#create-a-new-mkdocs-tacc-project