### PR TITLE
docs: clarify client vs theme test commands

### DIFF
--- a/docs/test.md
+++ b/docs/test.md
@@ -142,17 +142,21 @@ Some clients will offer automatic, remote build and deploy for testing.
 
 ### Test on Client Locally
 
-Use **Test Client Repo** tab as you follow [Test Locally](#test-locally) instructions.
+/// note |
 
-/// tab | Test `mkdocs-tacc` Repo
+As you follow [**Test Locally**](#test-locally) instructions, use **Test Client Repo** tab.
+
+//// tab | Test `mkdocs-tacc` Repo
 
 Ignore this tab. **Read the other tab.**
 
-///
-/// tab | Test on Client Repo
+////
+//// tab | Test on Client Repo
     select: True
 
 **Read this tab.** Ignore the other tab.
+
+////
 
 ///
 
@@ -213,7 +217,9 @@ To test `mkdocs-tacc` theme changes in real-time on a client repository:
 
     <small>Where `../mkdocs-tacc` is the path to your clone of this repository.</small>
 
-    //// tip | If changes since that command are not reflected, try:
+    //// tip |
+
+    If changes since that command are not reflected, try:
 
     ```shell
     pip uninstall mkdocs-tacc


### PR DESCRIPTION
## Overview

Clarify commands that work to test the client of this theme versus those that work to test the theme (i.e. this repo).

## Changes

- **changes** `test.md`

## Testing

1. Start server.
2. Open http://127.0.0.1:8000/test/.
3. Review changes for clarity and accuracy and usability.

## UI

https://github.com/user-attachments/assets/0312cf18-d953-41d7-80e5-92ee6fda0da6