### PR TITLE
docs: cite this software

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,33 @@
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+
+cff-version: 1.2.0
+title: MkDocs-TACC
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - name: Texas Advanced Computing Center
+    address: 10100 Burnet Rd (R8700)
+    city: Austin
+    country: US
+    post-code: '78758'
+    email: communications@tacc.utexas.edu
+    website: 'https://tacc.utexas.edu'
+identifiers:
+  - type: other
+    value: tacc/mkdocs-tacc
+    description: GitHub identity
+repository-code: 'https://github.com/tacc/mkdocs-tacc'
+url: 'https://tacc.github.io/mkdocs-tacc'
+abstract: >-
+  The theme for instances of MkDocs-software-powered
+  documentation maintained by Texas Advanced Computing
+  Center.
+keywords:
+  - tacc
+  - mkdocs
+commit: 5d121ed
+version: v1.0.0
+date-released: '2025-12-08'


### PR DESCRIPTION
## Overview

Cite this software.

## Related

> [!NOTE]
> This is a courtesy test of `.cff` file format for https://github.com/DesignSafe-CI applications.

## Changes

- **added** `CITATION.cff`

## Testing

1. **Before merge**, verify I just added a `CITATION.cff` file.
2. **After merge**, does "Cite this repository" show in repo home sidebar?

| 1 | 2 |
| - | - |
| <img width="286" height="247" alt="example" src="https://github.com/user-attachments/assets/25de8131-4f59-4687-a0ba-96ec2267f35b" /> | <img width="260" height="360" alt="mkdocs-tacc" src="https://github.com/user-attachments/assets/35148d7e-a760-4d35-a6e1-d40631c2f3f1" /> |