### PR TITLE
fix: image links should not have external icon

### DIFF
--- a/mkdocs_tacc/tacc_readthedocs/js/tacc-theme/addIconToExternalLinks.js
+++ b/mkdocs_tacc/tacc_readthedocs/js/tacc-theme/addIconToExternalLinks.js
@@ -20,7 +20,7 @@ document.querySelectorAll(`
 
 /* to add icon to external links in content */
 document.querySelectorAll(`
-  .rst-content a[href^="http"]
+  .rst-content a[href^="http"]:not(:has(img))
 `).forEach( a => {
   const icon = createIcon();
 


### PR DESCRIPTION
## Overview

Do not give image links a [↗] icon i.e. fix:

<img width="900" height="470" alt="problem illustration" src="https://github.com/user-attachments/assets/f1e57753-1ef6-4764-99cf-b01f5152f32b" />

## Related

- noticed in https://github.com/DesignSafe-CI/DS-User-Guide

## Changes

- **changed** selector

## Testing

Verify new selector does not select image links, but still selects text links.

## UI

Tested new query selector _in situ_.

<img width="900" height="470" alt="problem illustration" src="https://github.com/user-attachments/assets/f1e57753-1ef6-4764-99cf-b01f5152f32b" />
