### PR TITLE
fix: embed video misplaced

### DIFF
--- a/mkdocs_tacc/tacc_readthedocs/css/tacc-theme/readthedocs-revert.css
+++ b/mkdocs_tacc/tacc_readthedocs/css/tacc-theme/readthedocs-revert.css
@@ -1,4 +1,4 @@
 /* to undo ReadTheDocs styles for page content */
-.rst-content :not(img) {
+:where(.rst-content :not(img)) {
     all: revert;
 }


### PR DESCRIPTION
## Overview

An embedded video is misplaced at top of page instead of where it is authored in the document.

<details><summary>Technical Problem</summary>

A CSS "specificity battle" —

* `.rst-content :not(img)` too high
* `('./tacc-theme/bootstrap.css') layer(foundation.tacc)` thus too low

— causes `.embed-responsive` styles to be overridden.

</details>

## Related

- fixes https://github.com/DesignSafe-CI/DS-User-Guide/pull/259
- _maybe_ manifested since https://github.com/DesignSafe-CI/DS-User-Guide/releases/tag/v3.0.0

## Changes

- reduced specificity of a selector

## Testing

### Proper

0. Install update onto affected client e.g. https://github.com/DesignSafe-CI/DS-User-Guide.
1. Open affected page e.g. [/user-guide/tools/simulation/opensees/opensees/](http://127.0.0.1:8000/user-guide/tools/simulation/opensees/opensees/).
2. Verify video is not misplaced.

### In Situ

https://github.com/user-attachments/assets/1c0287cb-910c-451c-afa1-594eb31d1616

## UI

### On Affected Client

| Before | After |
| - | - |
| <img width="900" height="470" alt="before" src="https://github.com/user-attachments/assets/71fa3cde-19a4-43dc-85ab-b21eee136bd5" /> | <img width="900" height="470" alt="after" src="https://github.com/user-attachments/assets/b322dc4b-1178-4757-921d-e1d6a9d1719c" /> |
