### PR TITLE
fix: external icon missing margin in navigation

### DIFF
--- a/mkdocs_tacc/tacc_readthedocs/css/tacc-theme/core-docs.css
+++ b/mkdocs_tacc/tacc_readthedocs/css/tacc-theme/core-docs.css
@@ -93,7 +93,7 @@ u {
 /* Icons */
 
 /* `fa-external-link` applied by `../js/tacc-theme/addIconToExternalLinks.js` */
-:is(main, [role="main"]) a {
+.rst-content a {
   &:not([class*="card"], .c-card) > .fa-external-link {
     margin-left: 0.25em;
   }


### PR DESCRIPTION
## Overview

Missing margin on external window icon[^1] in breadcrumbs.

[^1]: (for links to external sites)

## Changes

- **changed** selector to include breadcrumbs

## Testing

1. Open any page/doc.
2. Verify icon after "Suggest an update via GitHub" is **not** directly against text.

## UI

https://github.com/user-attachments/assets/59fc5e89-b452-45f2-ae99-b856b0b52df1

